### PR TITLE
fix 修复公共模板引入路径和wx:key的错误

### DIFF
--- a/miniprogram/packageAPI/pages/api/choose-address/choose-address.wxml
+++ b/miniprogram/packageAPI/pages/api/choose-address/choose-address.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'chooseAddress'}}"/>

--- a/miniprogram/packageAPI/pages/api/choose-invoice-title/choose-invoice-title.wxml
+++ b/miniprogram/packageAPI/pages/api/choose-invoice-title/choose-invoice-title.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'chooseInvoiceTitle'}}"/>

--- a/miniprogram/packageAPI/pages/api/custom-message/custom-message.wxml
+++ b/miniprogram/packageAPI/pages/api/custom-message/custom-message.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'customMessage'}}"/>

--- a/miniprogram/packageAPI/pages/api/get-user-info/get-user-info.wxml
+++ b/miniprogram/packageAPI/pages/api/get-user-info/get-user-info.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getUserInfo'}}"/>

--- a/miniprogram/packageAPI/pages/api/jump/jump.wxml
+++ b/miniprogram/packageAPI/pages/api/jump/jump.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" />

--- a/miniprogram/packageAPI/pages/api/login/login.wxml
+++ b/miniprogram/packageAPI/pages/api/login/login.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Login'}}"/>

--- a/miniprogram/packageAPI/pages/api/request-payment/request-payment.wxml
+++ b/miniprogram/packageAPI/pages/api/request-payment/request-payment.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'requestPayment'}}"/>

--- a/miniprogram/packageAPI/pages/api/setting/setting.wxml
+++ b/miniprogram/packageAPI/pages/api/setting/setting.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'open/get/Setting'}}"/>

--- a/miniprogram/packageAPI/pages/api/share-button/share-button.wxml
+++ b/miniprogram/packageAPI/pages/api/share-button/share-button.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'share-button'}}"/>

--- a/miniprogram/packageAPI/pages/api/share/share.wxml
+++ b/miniprogram/packageAPI/pages/api/share/share.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'onShareAppMessage'}}"/>

--- a/miniprogram/packageAPI/pages/api/soter-authentication/soter-authentication.wxml
+++ b/miniprogram/packageAPI/pages/api/soter-authentication/soter-authentication.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'startSoterAuthentication'}}"/>

--- a/miniprogram/packageAPI/pages/api/subscribe-message/subscribe-message.wxml
+++ b/miniprogram/packageAPI/pages/api/subscribe-message/subscribe-message.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '订阅消息'}}"/>

--- a/miniprogram/packageAPI/pages/device/add-contact/add-contact.wxml
+++ b/miniprogram/packageAPI/pages/device/add-contact/add-contact.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'addPhoneContact'}}"/>

--- a/miniprogram/packageAPI/pages/device/bluetooth/bluetooth.wxml
+++ b/miniprogram/packageAPI/pages/device/bluetooth/bluetooth.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <wxs module="utils">
 module.exports.max = function(n1, n2) {

--- a/miniprogram/packageAPI/pages/device/capture-screen/capture-screen.wxml
+++ b/miniprogram/packageAPI/pages/device/capture-screen/capture-screen.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'onUserCaptureScreen'}}"/>

--- a/miniprogram/packageAPI/pages/device/clipboard-data/clipboard-data.wxml
+++ b/miniprogram/packageAPI/pages/device/clipboard-data/clipboard-data.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'get/set/ClipboardData'}}"/>

--- a/miniprogram/packageAPI/pages/device/get-battery-info/get-battery-info.wxml
+++ b/miniprogram/packageAPI/pages/device/get-battery-info/get-battery-info.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getBatteryInfo'}}"/>

--- a/miniprogram/packageAPI/pages/device/get-network-type/get-network-type.wxml
+++ b/miniprogram/packageAPI/pages/device/get-network-type/get-network-type.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getNetworkType'}}"/>

--- a/miniprogram/packageAPI/pages/device/get-system-info/get-system-info.wxml
+++ b/miniprogram/packageAPI/pages/device/get-system-info/get-system-info.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getSystemInfo'}}"/>

--- a/miniprogram/packageAPI/pages/device/ibeacon/ibeacon.wxml
+++ b/miniprogram/packageAPI/pages/device/ibeacon/ibeacon.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'iBeacon'}}"/>

--- a/miniprogram/packageAPI/pages/device/make-phone-call/make-phone-call.wxml
+++ b/miniprogram/packageAPI/pages/device/make-phone-call/make-phone-call.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'makePhoneCall'}}"/>

--- a/miniprogram/packageAPI/pages/device/on-accelerometer-change/on-accelerometer-change.wxml
+++ b/miniprogram/packageAPI/pages/device/on-accelerometer-change/on-accelerometer-change.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'onAccelerometerChange'}}"/>

--- a/miniprogram/packageAPI/pages/device/on-compass-change/on-compass-change.wxml
+++ b/miniprogram/packageAPI/pages/device/on-compass-change/on-compass-change.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'onCompassChange'}}"/>

--- a/miniprogram/packageAPI/pages/device/on-network-status-change/on-network-status-change.wxml
+++ b/miniprogram/packageAPI/pages/device/on-network-status-change/on-network-status-change.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'onNetworkStatusChange'}}"/>

--- a/miniprogram/packageAPI/pages/device/scan-code/scan-code.wxml
+++ b/miniprogram/packageAPI/pages/device/scan-code/scan-code.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'scanCode'}}"/>

--- a/miniprogram/packageAPI/pages/device/screen-brightness/screen-brightness.wxml
+++ b/miniprogram/packageAPI/pages/device/screen-brightness/screen-brightness.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'get/set/ScreenBrightness'}}"/>

--- a/miniprogram/packageAPI/pages/device/vibrate/vibrate.wxml
+++ b/miniprogram/packageAPI/pages/device/vibrate/vibrate.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'vibrate/Long/Short'}}"/>

--- a/miniprogram/packageAPI/pages/device/wifi/wifi.wxml
+++ b/miniprogram/packageAPI/pages/device/wifi/wifi.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Wi-Fi'}}"/>

--- a/miniprogram/packageAPI/pages/framework/resizable/resizable.wxml
+++ b/miniprogram/packageAPI/pages/framework/resizable/resizable.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 <wxs src="./resizable.wxs" module="resizable" />
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '屏幕旋转'}}"/>

--- a/miniprogram/packageAPI/pages/framework/two-way-bindings/two-way-bindings.wxml
+++ b/miniprogram/packageAPI/pages/framework/two-way-bindings/two-way-bindings.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '双向绑定'}}"/>

--- a/miniprogram/packageAPI/pages/framework/wxs/wxs.wxml
+++ b/miniprogram/packageAPI/pages/framework/wxs/wxs.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'WXS'}}"/>

--- a/miniprogram/packageAPI/pages/location/choose-location/choose-location.wxml
+++ b/miniprogram/packageAPI/pages/location/choose-location/choose-location.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'chooseLocation'}}"/>

--- a/miniprogram/packageAPI/pages/location/get-location/get-location.wxml
+++ b/miniprogram/packageAPI/pages/location/get-location/get-location.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getLocation'}}"/>

--- a/miniprogram/packageAPI/pages/location/open-location/open-location.wxml
+++ b/miniprogram/packageAPI/pages/location/open-location/open-location.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'openLocation'}}"/>

--- a/miniprogram/packageAPI/pages/media/background-audio/background-audio.wxml
+++ b/miniprogram/packageAPI/pages/media/background-audio/background-audio.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'backgroundAudio'}}"/>

--- a/miniprogram/packageAPI/pages/media/file/file.wxml
+++ b/miniprogram/packageAPI/pages/media/file/file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'saveFile'}}"/>

--- a/miniprogram/packageAPI/pages/media/image/image.wxml
+++ b/miniprogram/packageAPI/pages/media/image/image.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'choose/previewImage'}}"/>

--- a/miniprogram/packageAPI/pages/media/load-font-face/load-font-face.wxml
+++ b/miniprogram/packageAPI/pages/media/load-font-face/load-font-face.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'loadFontFace'}}"/>

--- a/miniprogram/packageAPI/pages/media/media-container/media-container.wxml
+++ b/miniprogram/packageAPI/pages/media/media-container/media-container.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '音视频合成'}}"/>

--- a/miniprogram/packageAPI/pages/media/video/video.wxml
+++ b/miniprogram/packageAPI/pages/media/video/video.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'chooseVideo'}}"/>

--- a/miniprogram/packageAPI/pages/media/voice/voice.wxml
+++ b/miniprogram/packageAPI/pages/media/voice/voice.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '录音/音频'}}"/>

--- a/miniprogram/packageAPI/pages/network/download-file/download-file.wxml
+++ b/miniprogram/packageAPI/pages/network/download-file/download-file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'downloadFile'}}"/>

--- a/miniprogram/packageAPI/pages/network/mdns/mdns.wxml
+++ b/miniprogram/packageAPI/pages/network/mdns/mdns.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'mDNS'}}"/>

--- a/miniprogram/packageAPI/pages/network/request/request.wxml
+++ b/miniprogram/packageAPI/pages/network/request/request.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'request'}}"/>

--- a/miniprogram/packageAPI/pages/network/udp-socket/udp-socket.wxml
+++ b/miniprogram/packageAPI/pages/network/udp-socket/udp-socket.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'startSoterAuthentication'}}"/>

--- a/miniprogram/packageAPI/pages/network/upload-file/upload-file.wxml
+++ b/miniprogram/packageAPI/pages/network/upload-file/upload-file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'uploadFile'}}"/>

--- a/miniprogram/packageAPI/pages/network/web-socket/web-socket.wxml
+++ b/miniprogram/packageAPI/pages/network/web-socket/web-socket.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'WebSocket'}}"/>

--- a/miniprogram/packageAPI/pages/nouse/custom-service/custom-service.wxml
+++ b/miniprogram/packageAPI/pages/nouse/custom-service/custom-service.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'scanCode'}}"/>

--- a/miniprogram/packageAPI/pages/nouse/sendMessage/sendMessage.wxml
+++ b/miniprogram/packageAPI/pages/nouse/sendMessage/sendMessage.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'sendMessage'}}"/>

--- a/miniprogram/packageAPI/pages/page/action-sheet/action-sheet.wxml
+++ b/miniprogram/packageAPI/pages/page/action-sheet/action-sheet.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'action-sheet'}}"/>

--- a/miniprogram/packageAPI/pages/page/animation/animation.wxml
+++ b/miniprogram/packageAPI/pages/page/animation/animation.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '关键帧动画'}}"/>

--- a/miniprogram/packageAPI/pages/page/canvas/canvas.wxml
+++ b/miniprogram/packageAPI/pages/page/canvas/canvas.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'createContext'}}"/>

--- a/miniprogram/packageAPI/pages/page/get-wxml-node-info/get-wxml-node-info.wxml
+++ b/miniprogram/packageAPI/pages/page/get-wxml-node-info/get-wxml-node-info.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'createSelectorQuery'}}"/>

--- a/miniprogram/packageAPI/pages/page/intersection-observer/intersection-observer.wxml
+++ b/miniprogram/packageAPI/pages/page/intersection-observer/intersection-observer.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'intersectionObserver'}}"/>

--- a/miniprogram/packageAPI/pages/page/modal/modal.wxml
+++ b/miniprogram/packageAPI/pages/page/modal/modal.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'modal'}}"/>

--- a/miniprogram/packageAPI/pages/page/navigation-bar-loading/navigation-bar-loading.wxml
+++ b/miniprogram/packageAPI/pages/page/navigation-bar-loading/navigation-bar-loading.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'navigationBarLoading'}}"/>

--- a/miniprogram/packageAPI/pages/page/navigator/navigator.wxml
+++ b/miniprogram/packageAPI/pages/page/navigator/navigator.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'navigateTo/Back, redirectTo'}}"/>

--- a/miniprogram/packageAPI/pages/page/page-scroll/page-scroll.wxml
+++ b/miniprogram/packageAPI/pages/page/page-scroll/page-scroll.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'pageScrollTo'}}"/>

--- a/miniprogram/packageAPI/pages/page/pull-down-refresh/pull-down-refresh.wxml
+++ b/miniprogram/packageAPI/pages/page/pull-down-refresh/pull-down-refresh.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'on/stopPullDownRefresh'}}"/>

--- a/miniprogram/packageAPI/pages/page/set-navigation-bar-title/set-navigation-bar-title.wxml
+++ b/miniprogram/packageAPI/pages/page/set-navigation-bar-title/set-navigation-bar-title.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'setNaivgationBarTitle'}}"/>

--- a/miniprogram/packageAPI/pages/page/set-navigation-bar-title/set-navigation-bar-title.wxss
+++ b/miniprogram/packageAPI/pages/page/set-navigation-bar-title/set-navigation-bar-title.wxss
@@ -1,4 +1,4 @@
-/* @import "../../../common/lib/weui.wxss"; */
+/* @import "/common/lib/weui.wxss"; */
 
 .weui-label{
   width: 5em;

--- a/miniprogram/packageAPI/pages/page/toast/toast.wxml
+++ b/miniprogram/packageAPI/pages/page/toast/toast.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'toast'}}"/>

--- a/miniprogram/packageAPI/pages/performance/get-performance/get-performance.wxml
+++ b/miniprogram/packageAPI/pages/performance/get-performance/get-performance.wxml
@@ -1,6 +1,6 @@
 
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getPerformance'}}"/>

--- a/miniprogram/packageAPI/pages/storage/get-background-fetch-data/get-background-fetch-data.wxml
+++ b/miniprogram/packageAPI/pages/storage/get-background-fetch-data/get-background-fetch-data.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getBackgroundFetchData'}}"/>

--- a/miniprogram/packageAPI/pages/storage/get-background-prefetch-data/get-background-prefetch-data.wxml
+++ b/miniprogram/packageAPI/pages/storage/get-background-prefetch-data/get-background-prefetch-data.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 <view class="container page" data-weui-theme="{{ theme }}">
 	<template is="head" data="{{ title: 'getBackgroundFetchData' }}" />
 	<view class="page-body">

--- a/miniprogram/packageAPI/pages/storage/storage/storage.wxml
+++ b/miniprogram/packageAPI/pages/storage/storage/storage.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'get/set/clearStorage'}}"/>

--- a/miniprogram/packageAPI/pages/worker/worker/worker.wxml
+++ b/miniprogram/packageAPI/pages/worker/worker/worker.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Worker'}}"/>

--- a/miniprogram/packageCloud/pages/database/crud/crud.wxml
+++ b/miniprogram/packageCloud/pages/database/crud/crud.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'CRUD'}}" />

--- a/miniprogram/packageCloud/pages/database/db-permission/db-permission.wxml
+++ b/miniprogram/packageCloud/pages/database/db-permission/db-permission.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Permission'}}" />

--- a/miniprogram/packageCloud/pages/database/server-date/server-date.wxml
+++ b/miniprogram/packageCloud/pages/database/server-date/server-date.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'db.serverDate'}}"/>

--- a/miniprogram/packageCloud/pages/nouse/crud-detail/crud-detail.wxml
+++ b/miniprogram/packageCloud/pages/nouse/crud-detail/crud-detail.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'CRUD'}}" />

--- a/miniprogram/packageCloud/pages/scf/get-wx-context/get-wx-context.wxml
+++ b/miniprogram/packageCloud/pages/scf/get-wx-context/get-wx-context.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getWXContext'}}"/>

--- a/miniprogram/packageCloud/pages/scf/scf-database/scf-database.wxml
+++ b/miniprogram/packageCloud/pages/scf/scf-database/scf-database.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Database'}}" />

--- a/miniprogram/packageCloud/pages/scf/scf-openapi/scf-openapi.wxml
+++ b/miniprogram/packageCloud/pages/scf/scf-openapi/scf-openapi.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '云函数中使用微信开放能力'}}" />

--- a/miniprogram/packageCloud/pages/scf/scf-storage/scf-storage.wxml
+++ b/miniprogram/packageCloud/pages/scf/scf-storage/scf-storage.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Storage'}}" />

--- a/miniprogram/packageCloud/pages/storage/cloud-file-component/cloud-file-component.wxml
+++ b/miniprogram/packageCloud/pages/storage/cloud-file-component/cloud-file-component.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'Component Support'}}" />

--- a/miniprogram/packageCloud/pages/storage/delete-file/delete-file.wxml
+++ b/miniprogram/packageCloud/pages/storage/delete-file/delete-file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'deleteFile'}}" />

--- a/miniprogram/packageCloud/pages/storage/download-file/download-file.wxml
+++ b/miniprogram/packageCloud/pages/storage/download-file/download-file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'downloadFile'}}" />

--- a/miniprogram/packageCloud/pages/storage/get-temp-file-url/get-temp-file-url.wxml
+++ b/miniprogram/packageCloud/pages/storage/get-temp-file-url/get-temp-file-url.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'getTempFileURL'}}" />

--- a/miniprogram/packageCloud/pages/storage/upload-file/upload-file.wxml
+++ b/miniprogram/packageCloud/pages/storage/upload-file/upload-file.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'uploadFile'}}" />

--- a/miniprogram/packageCloud/pages/user/user-authentication/user-authentication.wxml
+++ b/miniprogram/packageCloud/pages/user/user-authentication/user-authentication.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'User Authentication'}}"/>

--- a/miniprogram/packageComponent/pages/camera-scan-code/camera-scan-code.wxml
+++ b/miniprogram/packageComponent/pages/camera-scan-code/camera-scan-code.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'camera'}}"/>

--- a/miniprogram/packageComponent/pages/content/icon/icon.wxml
+++ b/miniprogram/packageComponent/pages/content/icon/icon.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'icon'}}"/>

--- a/miniprogram/packageComponent/pages/content/progress/progress.wxml
+++ b/miniprogram/packageComponent/pages/content/progress/progress.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'progress'}}"/>

--- a/miniprogram/packageComponent/pages/content/rich-text/rich-text.wxml
+++ b/miniprogram/packageComponent/pages/content/rich-text/rich-text.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'rich-text'}}"/>

--- a/miniprogram/packageComponent/pages/form/checkbox/checkbox.wxml
+++ b/miniprogram/packageComponent/pages/form/checkbox/checkbox.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'checkbox'}}"/>

--- a/miniprogram/packageComponent/pages/form/form/form.wxml
+++ b/miniprogram/packageComponent/pages/form/form/form.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'form'}}"/>

--- a/miniprogram/packageComponent/pages/form/label/label.wxml
+++ b/miniprogram/packageComponent/pages/form/label/label.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'label'}}"/>

--- a/miniprogram/packageComponent/pages/form/picker-view/picker-view.wxml
+++ b/miniprogram/packageComponent/pages/form/picker-view/picker-view.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'picker-view'}}"/>

--- a/miniprogram/packageComponent/pages/form/radio/radio.wxml
+++ b/miniprogram/packageComponent/pages/form/radio/radio.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'radio'}}"/>

--- a/miniprogram/packageComponent/pages/form/slider/slider.wxml
+++ b/miniprogram/packageComponent/pages/form/slider/slider.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'slider'}}"/>

--- a/miniprogram/packageComponent/pages/form/switch/switch.wxml
+++ b/miniprogram/packageComponent/pages/form/switch/switch.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'switch'}}"/>

--- a/miniprogram/packageComponent/pages/form/textarea/textarea.wxml
+++ b/miniprogram/packageComponent/pages/form/textarea/textarea.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'textarea'}}"/>

--- a/miniprogram/packageComponent/pages/map-styles/map-styles.wxml
+++ b/miniprogram/packageComponent/pages/map-styles/map-styles.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'map'}}"/>

--- a/miniprogram/packageComponent/pages/media/camera/camera.wxml
+++ b/miniprogram/packageComponent/pages/media/camera/camera.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <mp-navigation-bar title="camera" back="{{true}}"></mp-navigation-bar>
 <scroll-view class="page-scroll-view" scroll-y type="list">

--- a/miniprogram/packageComponent/pages/media/live-player/live-player.wxml
+++ b/miniprogram/packageComponent/pages/media/live-player/live-player.wxml
@@ -1,5 +1,5 @@
-	<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+	<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'live-player'}}"/>

--- a/miniprogram/packageComponent/pages/media/live-pusher/live-pusher.wxml
+++ b/miniprogram/packageComponent/pages/media/live-pusher/live-pusher.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'live-pusher'}}"/>

--- a/miniprogram/packageComponent/pages/media/video/picture-in-picture.wxml
+++ b/miniprogram/packageComponent/pages/media/video/picture-in-picture.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '小窗模式'}}"/>

--- a/miniprogram/packageComponent/pages/media/video/video.wxml
+++ b/miniprogram/packageComponent/pages/media/video/video.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <mp-navigation-bar title="video" back="{{true}}"></mp-navigation-bar>
 <scroll-view class="page-scroll-view" scroll-y type="list">

--- a/miniprogram/packageComponent/pages/obstacle-free/aria-component/aria-component.wxml
+++ b/miniprogram/packageComponent/pages/obstacle-free/aria-component/aria-component.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: '无障碍访问'}}"/>

--- a/miniprogram/packageComponent/pages/official-account/official-account.wxml
+++ b/miniprogram/packageComponent/pages/official-account/official-account.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'official-account'}}"/>

--- a/miniprogram/packageComponent/pages/open/ad/ad.wxml
+++ b/miniprogram/packageComponent/pages/open/ad/ad.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 <view class="container page" data-weui-theme="{{ theme }}">
 	<template is="head" data="{{ title: 'ad' }}" />
 	<view class="page-body">

--- a/miniprogram/packageComponent/pages/open/open-data/open-data.wxml
+++ b/miniprogram/packageComponent/pages/open/open-data/open-data.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <!--
       <open-data type="userAvatarUrl" lang="zh_CN"></open-data>

--- a/miniprogram/packageComponent/pages/view/cover-view/cover-view.wxml
+++ b/miniprogram/packageComponent/pages/view/cover-view/cover-view.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'cover-view'}}"/>

--- a/miniprogram/packageComponent/pages/view/movable-view/movable-view.wxml
+++ b/miniprogram/packageComponent/pages/view/movable-view/movable-view.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml"/>
-<import src="../../../common/foot.wxml"/>
+<import src="/common/head.wxml"/>
+<import src="/common/foot.wxml"/>
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'movable-view'}}"/>

--- a/miniprogram/packageSkyline/pages/preview/index.json
+++ b/miniprogram/packageSkyline/pages/preview/index.json
@@ -3,7 +3,6 @@
     "previewer": "../../components/previewer/index"
   },
   "navigationStyle": "custom",
-  "backgroundColorContent": "#00000000",
   "disableScroll": true,
   "renderer": "skyline"
 }

--- a/miniprogram/packageSkyline/pages/scroll-view/index.less
+++ b/miniprogram/packageSkyline/pages/scroll-view/index.less
@@ -1,4 +1,4 @@
-@import "../../../common/reset.wxss";
+@import "/common/reset.wxss";
 
 .page-section-spacing{
   margin-top: 30px;

--- a/miniprogram/page/API/components/set-tab-bar/set-tab-bar.wxml
+++ b/miniprogram/page/API/components/set-tab-bar/set-tab-bar.wxml
@@ -1,5 +1,5 @@
-<import src="../../../common/head.wxml" />
-<import src="../../../common/foot.wxml" />
+<import src="/common/head.wxml" />
+<import src="/common/foot.wxml" />
 
 <view class="container page" data-weui-theme="{{theme}}">
   <template is="head" data="{{title: 'tabBar'}}"/>

--- a/miniprogram/page/API/index.wxml
+++ b/miniprogram/page/API/index.wxml
@@ -8,7 +8,7 @@
   </view>
   <view class="index-bd">
     <view class="kind-list">
-      <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+      <block wx:for-items="{{list}}" wx:key="id">
         <view class="kind-list-item">
           <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
             <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
           </view>
           <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
             <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-              <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+              <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
                 <view wx:if="{{page.url !== '@set-tab-bar'}}">
                   <navigator url="../../packageAPI/pages/{{item.id}}/{{page.url}}" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.zh}}</navigator>
                   <view class="navigator-arrow"></view>

--- a/miniprogram/page/animation/index.wxml
+++ b/miniprogram/page/animation/index.wxml
@@ -8,7 +8,7 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for-items="{{list}}" wx:key="id">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
                   <view wx:if="{{page.appid}}">
                     <navigator target="miniProgram" open-type="navigate" app-id="{{page.appid}}" path="" extra-data="" version="release" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.name}}</navigator>
                     <view class="navigator-arrow"></view>

--- a/miniprogram/page/cloud/index.wxml
+++ b/miniprogram/page/cloud/index.wxml
@@ -8,7 +8,7 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for-items="{{list}}" wx:key="id">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="url">
                   <view>
                     <navigator url="../../packageCloud/pages/{{item.id}}/{{page.url}}" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.zh}}</navigator>
                     <view class="navigator-arrow"></view>

--- a/miniprogram/page/component/index.wxml
+++ b/miniprogram/page/component/index.wxml
@@ -8,7 +8,7 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for-items="{{list}}" wx:key="id">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
                   <view wx:if="{{page.appid}}">
                     <navigator target="miniProgram" open-type="navigate" app-id="{{page.appid}}" path="" extra-data="" version="release" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.name}}</navigator>
                     <view class="navigator-arrow"></view>


### PR DESCRIPTION
- 公共的 head 和 foot 引入路径是错误的，改成了以 / 开头的绝对路径方式
- wx:key 也有一些错误的语法，如 wx:key="{{item.id}}" 语法是错的