### PR TITLE
fix: GLTFLoader加载有额外纹理配置的gltf模型

### DIFF
--- a/miniprogram/packageAPI/pages/ar/loaders/gltf-loader.js
+++ b/miniprogram/packageAPI/pages/ar/loaders/gltf-loader.js
@@ -999,7 +999,7 @@ export function registerGLTFLoader(THREE) {
       var json = this.json;
       var options = this.options;
       var textureLoader = this.textureLoader;
-      var URL = global.URL;
+      // var URL = global.URL;
       var textureDef = json.textures[textureIndex];
       var textureExtensions = textureDef.extensions || {};
       var source;
@@ -1013,11 +1013,14 @@ export function registerGLTFLoader(THREE) {
       if (source.bufferView !== undefined) {
         sourceURI = parser.getDependency('bufferView', source.bufferView).then(function(bufferView) {
           isObjectURL = true;
-          var blob = new global.Blob([bufferView], {
-            type: source.mimeType
-          });
-          sourceURI = URL.createObjectURL(blob);
-          return sourceURI
+          // var blob = new global.Blob([bufferView], {
+          //   type: source.mimeType
+          // });
+          // sourceURI = URL.createObjectURL(blob);
+          // 小程序不支持 Blob 对象，使用 base64 编码的字符串来创建 data URI
+          const base64Str = wx.arrayBufferToBase64(bufferView);
+          sourceURI = `data:${source.mimeType};base64,${base64Str}`;
+          return sourceURI;
         })
       }
       return Promise.resolve(sourceURI).then(function(sourceURI) {
@@ -1030,7 +1033,7 @@ export function registerGLTFLoader(THREE) {
         })
       }).then(function(texture) {
         if (isObjectURL === true) {
-          URL.revokeObjectURL(sourceURI)
+          // URL.revokeObjectURL(sourceURI)
         }
         texture.flipY = false;
         if (textureDef.name !== undefined) texture.name = textureDef.name;


### PR DESCRIPTION
修复GLTFLoader加载有额外纹理配置的gltf模型时报错：
<img width="334" alt="image" src="https://user-images.githubusercontent.com/38858428/237030409-4b427500-8151-491d-b65e-e88f3a078c79.png">

undefined is not a constructor (evaluating 'new global.Blob([e], { type: r.mimeType })')

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/38858428/237030221-c330af8f-e042-4727-a674-a275232db02e.png">

原因：
微信小程序不支持Blob 对象

修复方式：
使用 base64 编码的字符串来创建 data URI         