### PR TITLE
fix: 修复手势系统页面，点击小球大小没变

### DIFF
--- a/miniprogram/packageSkyline/pages/worklet/gesture/index.js
+++ b/miniprogram/packageSkyline/pages/worklet/gesture/index.js
@@ -14,7 +14,10 @@ Page({
     const x = shared(0);
     const y = shared(0);
     const pressed = shared(false);
-    const scale = derived(() => spring(pressed.value ? 1.2 : 1));
+    const scale = derived(() => {
+      'worklet'
+      return spring(pressed.value ? 1.2 : 1)
+    });
     this.applyAnimatedStyle('.circle', () => {
       'worklet';
       return {


### PR DESCRIPTION
derived 的参数需要使用 WorkletFunction 类型