### PR TITLE
fix: deprecate `wx:for-items` WXML directive by `wx:for`

### DIFF
--- a/miniprogram/page/API/index.wxml
+++ b/miniprogram/page/API/index.wxml
@@ -8,7 +8,7 @@
   </view>
   <view class="index-bd">
     <view class="kind-list">
-      <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+      <block wx:for="{{list}}" wx:key="{{item.id}}">
         <view class="kind-list-item">
           <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
             <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
           </view>
           <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
             <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-              <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+              <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*item">
                 <view wx:if="{{page.url !== '@set-tab-bar'}}">
                   <navigator url="../../packageAPI/pages/{{item.id}}/{{page.url}}" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.zh}}</navigator>
                   <view class="navigator-arrow"></view>

--- a/miniprogram/page/animation/index.wxml
+++ b/miniprogram/page/animation/index.wxml
@@ -8,14 +8,14 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for="{{list}}" wx:key="{{item.id}}">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*item">
                   <view wx:if="{{page.appid}}">
                     <navigator target="miniProgram" open-type="navigate" app-id="{{page.appid}}" path="" extra-data="" version="release" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.name}}</navigator>
                     <view class="navigator-arrow"></view>

--- a/miniprogram/page/cloud/index.wxml
+++ b/miniprogram/page/cloud/index.wxml
@@ -8,7 +8,7 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for="{{list}}" wx:key="{{item.id}}">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*item">
                   <view>
                     <navigator url="../../packageCloud/pages/{{item.id}}/{{page.url}}" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.zh}}</navigator>
                     <view class="navigator-arrow"></view>

--- a/miniprogram/page/component/index.wxml
+++ b/miniprogram/page/component/index.wxml
@@ -8,7 +8,7 @@
     </view>
     <view class="index-bd">
       <view class="kind-list">
-        <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+        <block wx:for="{{list}}" wx:key="{{item.id}}">
           <view class="kind-list-item">
             <view id="{{item.id}}" class="kind-list-item-hd {{item.open ? 'kind-list-item-hd-show' : ''}}" bindtap="kindToggle">
               <view class="kind-list-text">{{item.name}}</view>
@@ -17,7 +17,7 @@
             </view>
             <view class="kind-list-item-bd {{item.open ? 'kind-list-item-bd-show' : ''}}">
               <view class="navigator-box {{item.open ? 'navigator-box-show' : ''}}">
-                <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*item">
                   <view wx:if="{{page.appid}}">
                     <navigator target="miniProgram" open-type="navigate" app-id="{{page.appid}}" path="" extra-data="" version="release" class="navigator {{index + 1 === item.pages.length ? '' : 'navigator-bottom-line'}}">{{page.name}}</navigator>
                     <view class="navigator-arrow"></view>


### PR DESCRIPTION
`wx:for-items` is a very former alias for `wx:for`, which is deprecated since too similar with `wx:for-item`.

`wx:for-items` is completely removed in the latest version of `glass-easel-template-compiler`, so this is a fix for it.