### PR TITLE
fix(ar): 修复 threejs-miniprogram 导入路径问题

### DIFF
--- a/miniprogram/packageAPI/pages/ar/body-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/body-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/cameraBuffer-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/cameraBuffer-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/depth-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/depth-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/face-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/face-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/hand-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/hand-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/ocr-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/ocr-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/osd-ar/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/osd-ar/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-body-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-body-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-depth-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-depth-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-face-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-face-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-hand-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-hand-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-ocr-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-ocr-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/photo-shoe-detect/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/photo-shoe-detect/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/plane-ar-3dof/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/plane-ar-3dof/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/plane-ar-v2-depth/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/plane-ar-v2-depth/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/plane-ar-v2-marker/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/plane-ar-v2-marker/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/plane-ar-v2/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/plane-ar-v2/behavior.js
@@ -1,6 +1,6 @@
 import {
   createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
   registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/plane-ar/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/plane-ar/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/visionkit-basic-v2/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/visionkit-basic-v2/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'

--- a/miniprogram/packageAPI/pages/ar/visionkit-basic/behavior.js
+++ b/miniprogram/packageAPI/pages/ar/visionkit-basic/behavior.js
@@ -1,6 +1,6 @@
 import {
     createScopedThreejs
-} from './threejs-miniprogram'
+} from 'threejs-miniprogram'
 import {
     registerGLTFLoader
 } from '../loaders/gltf-loader'


### PR DESCRIPTION
将所有 AR 相关行为文件中的 threejs-miniprogram 导入路径从相对路径 './threejs-miniprogram' 修改为模块路径 'threejs-miniprogram'，确保导入路径的正确性。

影响文件：
- body-detect
- cameraBuffer-detect
- depth-detect
- face-detect 等20个 AR 功能模块的 behavior.js 文件